### PR TITLE
Some OS X Fixes

### DIFF
--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -6,6 +6,8 @@ if (CMAKE_HOST_APPLE)
         /usr/local
         /opt/local
     )
+    INCLUDE_DIRECTORIES(/usr/include)
+    INCLUDE_DIRECTORIES(/usr/local/include)
 else (CMAKE_HOST_APPLE)
     # OS X is a Unix, but it's not a normal Unix as far as search paths go.
     if (CMAKE_HOST_UNIX)

--- a/tools/config_main.hpp.in
+++ b/tools/config_main.hpp.in
@@ -14,7 +14,6 @@
 #else
     #ifdef __APPLE__
         #include <OpenGL/gl3.h>
-        #include <GL/glew.h>
         #define GLFW_INCLUDE_GLCOREARB
         #include <GLFW/glfw3.h>
         // Needed so we can disable retina support for our window.

--- a/tools/include/al_engine.hpp
+++ b/tools/include/al_engine.hpp
@@ -16,11 +16,12 @@
 #ifdef __APPLE__
     #include <OpenAL/al.h>
     #include <OpenAL/alc.h>
+    #include <OpenAL/alure.h>
 #else
     #include <AL/al.h>
     #include <AL/alc.h>
+    #include <AL/alure.h>
 #endif
-#include <AL/alure.h> // Check if in MacOS or Win needs other stuff here
 
 
 #include "types.hpp"

--- a/tools/src/gl_engine.cpp
+++ b/tools/src/gl_engine.cpp
@@ -60,7 +60,7 @@ int GlEngine::initGL(OS::OS& os) {
     // Use the GL3 way to get the version number
     glGetIntegerv(GL_MAJOR_VERSION, &OpenGLVersion[0]);
     glGetIntegerv(GL_MINOR_VERSION, &OpenGLVersion[1]);
-    std::cout << "Using OpenGL " << OpenGLVersion[0] << "." << OpenGLVersion[1] << "\n";
+    std::cerr << "Using OpenGL " << OpenGLVersion[0] << "." << OpenGLVersion[1] << "\n";
 
     // Sanity check to make sure we are at least in a good major version number.
     assert((OpenGLVersion[0] > 1) && (OpenGLVersion[0] < 5));
@@ -324,6 +324,11 @@ int GlEngine::initGL(OS::OS& os) {
     glAttachShader(shaderProgram, fragmentShader);
     check_gl_error();
 
+    // Bind attributes indexes
+    glBindAttribLocation(shaderProgram, sh_in_Position, "in_Position");
+    glBindAttribLocation(shaderProgram, sh_in_Color, "in_Color");
+    glBindAttribLocation(shaderProgram, sh_in_UV, "in_UV");
+
     // Link shader program
     glLinkProgram(shaderProgram);
 
@@ -346,11 +351,6 @@ int GlEngine::initGL(OS::OS& os) {
         free(shaderProgramInfoLog);
         return -1;
     }
-
-    // Bind attributes indexes
-    glBindAttribLocation(shaderProgram, sh_in_Position, "in_Position");
-    glBindAttribLocation(shaderProgram, sh_in_Color, "in_Color");
-    glBindAttribLocation(shaderProgram, sh_in_UV, "in_UV");
 
     modelId = glGetUniformLocation(shaderProgram, "in_Model");
     viewId  = glGetUniformLocation(shaderProgram, "in_View");
@@ -413,7 +413,7 @@ void GlEngine::UpdScreen (OS::OS& os, const double delta) {
         auto tdata = glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, 320*240*4 ,
                 GL_MAP_WRITE_BIT |GL_MAP_INVALIDATE_BUFFER_BIT );
         if (tdata != nullptr) {
-            //std::fill_n(tdata, 320*240, 0xFF800000);
+            std::fill_n((unsigned*)tdata, 320*240, 0xFF800000);
             if (painter) {
                 painter(tdata);
             }

--- a/tools/tda_view.cpp
+++ b/tools/tda_view.cpp
@@ -105,7 +105,7 @@ int main (int argc, char* argv[]) {
         // Ugly hack
         for(unsigned long i=0; i < 10000000 ; i++) {
             ;
-        }
+        } 
 
         gl.UpdScreen (glfwos, delta);
     }


### PR DESCRIPTION
Attribute bindings have to be setup before linking a shader program.
Also changed a few other small things that the compiler was complaining about.
This let me run at least tda_view successfully.
